### PR TITLE
Fix oracle to gdf

### DIFF
--- a/hhnk_research_tools/sql_functions.py
+++ b/hhnk_research_tools/sql_functions.py
@@ -412,7 +412,9 @@ def database_to_gdf(
     import oracledb  # Import here to prevent dependency
 
     if "sdo_util.to_wktgeometry" in sql.lower():
-        raise ValueError("Dont pass sdo_util.to_wkt_geometry in the sql. It will be done here.")
+        raise ValueError(
+            "Dont pass sdo_util.to_wkt_geometry in the sql. It will be added here. Just use e.g. SHAPE as column."
+        )
 
     with oracledb.connect(**db_dict) as con:
         cur = oracledb.Cursor(con)
@@ -471,7 +473,7 @@ def database_to_gdf(
         try:
             cur.execute(sql2)
         except Exception as e:
-            print("fail")
+            print("Failed request. Here is the sql:")
             print(sql2)
             raise e
 
@@ -492,24 +494,3 @@ def database_to_gdf(
         if "geometry" in df.columns:
             df = df.set_geometry(gpd.GeoSeries(df["geometry"].apply(_oracle_curve_polygon_to_linear)), crs=crs)
         return df, sql2
-
-
-# %%
-if __name__ == "__main__":
-    sql = """SELECT a.OBJECTID, a.CODE, a.NAAM, a.OBSCODE, a.SPOC_CODE, a.SOORTRIOOLGEMAALCODE, 
-                a.LOOST_OP_RWZI_CODE, a.LOOST_OP_RIOOLGEMAAL_CODE, a.SOORTRIOOLGEMAAL, a.REGIEKAMER, 
-                b.NAAM as ZUIVERINGSKRING, a.SHAPE
-            FROM CS_OBJECTEN.RIOOLGEMAAL_EVW a
-            left outer join CS_OBJECTEN.ZUIVERINGSKRING_EVW b
-            on a.LOOST_OP_RWZI_CODE = b.RWZICODE
-            FETCH FIRST 10 ROWS ONLY
-            """
-    from tests_hrt.local_settings import DATABASES
-
-    db_dicts = {
-        "aquaprd": DATABASES.get("aquaprd_lezen", None),
-        "bgt": DATABASES.get("bgt_lezen", None),
-        "csoprd": DATABASES.get("csoprd", None),
-    }
-    db_dict = db_dicts["csoprd"]
-    columns = None

--- a/hhnk_research_tools/sql_functions.py
+++ b/hhnk_research_tools/sql_functions.py
@@ -394,7 +394,7 @@ def database_to_gdf(
     sql: str
         oracledb 12 sql to execute
         Takes only one sql statement at a time, ';' is removed
-    columns: list #TODO allow for dict input
+    columns: list
         When not provided, get the column names from the external table
         geometry columns 'SHAPE' or 'GEOMETRIE' are renamed to 'geometry'
     lower_cols : bool
@@ -452,16 +452,8 @@ def database_to_gdf(
         elif isinstance(columns, list):
             cols_dict = {c: c for c in columns}
             columns_out = cols_dict.keys()
-        elif isinstance(columns, dict):
-            # van name : name_out naar
-            # name_out : name as name_out
-            cols_dict = {v: f"{k} as {v}" for k, v in columns.items()}
-            for geomcol in ["shape", "geometrie", "geometry"]:
-                if geomcol in cols_dict.keys():
-                    cols_dict[geomcol] = geomcol
-                if geomcol.upper() in cols_dict.keys():
-                    cols_dict[geomcol.upper()] = geomcol
-            columns_out = columns.values()
+        else:
+            raise ValueError("Columns must be a list {columns}")
 
         # Modify geometry column name to get WKT geometry
         for key, col in cols_dict.items():

--- a/hhnk_research_tools/sql_functions.py
+++ b/hhnk_research_tools/sql_functions.py
@@ -469,14 +469,19 @@ def database_to_gdf(
                 if col.lower() == geomcol:
                     cols_dict[key] = f"sdo_util.to_wktgeometry({col}) as geometry"
                 # Find pattern e.g.: a.shape
-                if re.search(pattern=rf"\w*\.?{geomcol}", string=col.lower()):
+                if re.search(pattern=rf"(^|\w+\.){geomcol.lower()}$", string=col.lower()):
                     cols_dict[key] = f"sdo_util.to_wktgeometry({col}) as geometry"
 
         col_select = ", ".join(cols_dict.values())
         sql2 = sql.replace(select_search_str, f"SELECT {col_select} ")
 
         # Execute modified sql request
-        cur.execute(sql2)
+        try:
+            cur.execute(sql2)
+        except Exception as e:
+            print("fail")
+            print(sql2)
+            raise e
 
         # load cursor to dataframe
         df = pd.DataFrame(cur.fetchall(), columns=columns_out)

--- a/tests_hrt/ftest_sql_functions.py
+++ b/tests_hrt/ftest_sql_functions.py
@@ -42,6 +42,9 @@ def test_database_to_gdf():
     assert gdf.loc[0, "code"] == "KGM-Q-29234"
 
 
+# %%
+
+
 def test_database_to_gdf_no_cols():
     # %%
     sql = """SELECT a.OBJECTID, a.CODE, a.NAAM,a.REGIEKAMER, 


### PR DESCRIPTION
Waren wat problemen als er niet `SELECT *` werd gebruikt, maar `select *`. 

Ook bij het aanbieden van kolomnamen in de sql ging niet goed met de geometrie.

- Afvangen dat sdo_util.to_wktgeometry niet in de input sql mag staan.

- Bool input `lower_cols` toegevoegd om de output df standaard column namen met alleen maar lowercase terug te geven.